### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes should be reviewed by a member of the @brand-reviewers team
+* @primer/brand-reviewers


### PR DESCRIPTION
Proposing the addition of a CODEOWNERS file assigned to the Primer `brand-reviewers` group. This should help manage the current ownership of the code in this repo.

It should also make it easier to set up review standards and reviewers, which would help ensure contributions and automated PRs like Dependabot updates are addressed in a timely fashion. My hope is that this would, in turn, protect against the kind of friction we encountered when `primer/doctocat`'s Gatsby version got so outdated it was too painful to update.