### PR TITLE
Add related content support and navigation using keywords

### DIFF
--- a/.changeset/hide-mean-turkeys.md
+++ b/.changeset/hide-mean-turkeys.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Added OpenGraph tags for improved social sharing experience.

--- a/.changeset/mean-turkeys-hide.md
+++ b/.changeset/mean-turkeys-hide.md
@@ -2,7 +2,7 @@
 '@primer/doctocat-nextjs': patch
 ---
 
-Enabled related content navigation using `keywords` field in Markdown frontmatter.
+Enabled related content navigation using `keywords` and `related` properties in Markdown frontmatter.
 
 Example:
 
@@ -21,3 +21,11 @@ keywords: ['keyword', 'another keyword']
 ```
 
 The matching keyword values above across both pages, will enable automatic related content navigation between the two pages.
+
+or using the `related` property:
+
+```
+---
+related: [{title: External link example, href: https://example.com}]
+---
+```

--- a/.changeset/mean-turkeys-hide.md
+++ b/.changeset/mean-turkeys-hide.md
@@ -1,0 +1,23 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Enabled related content navigation using `keywords` field in Markdown frontmatter.
+
+Example:
+
+```
+---
+title: Page A
+keywords: ['keyword', 'another keyword']
+---
+```
+
+```
+---
+title: Page B
+keywords: ['keyword', 'another keyword']
+---
+```
+
+The matching keyword values above across both pages, will enable automatic related content navigation between the two pages.

--- a/.changeset/turkeys-mean-hide.md
+++ b/.changeset/turkeys-mean-hide.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Fixed accessibility violations arising from duplicate landmarks and missing aria labels.

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   release-canary:
-    if: false
-    #if: ${{ github.repository == 'primer/doctocat-nextjs' }}
+    if: ${{ github.repository == 'primer/doctocat-nextjs' }}
     name: Canary
     runs-on: ubuntu-latest
     steps:

--- a/packages/site/pages/content-examples/kitchen-sink.mdx
+++ b/packages/site/pages/content-examples/kitchen-sink.mdx
@@ -7,6 +7,7 @@ action-1-text: Primary action
 action-1-link: /
 action-2-text: Secondary action
 action-2-link: /content-examples/kitchen-sink
+keywords: ['kitchen sink', 'introduction', 'simple']
 ---
 
 import {DoDontContainer, Do, Dont, Caption} from '@primer/doctocat-nextjs'

--- a/packages/site/pages/content-examples/kitchen-sink.mdx
+++ b/packages/site/pages/content-examples/kitchen-sink.mdx
@@ -8,6 +8,7 @@ action-1-link: /
 action-2-text: Secondary action
 action-2-link: /content-examples/kitchen-sink
 keywords: ['accessibility', 'introduction', 'simple']
+related: [{title: External link example, href: https://primer.style}]
 ---
 
 import {DoDontContainer, Do, Dont, Caption} from '@primer/doctocat-nextjs'

--- a/packages/site/pages/content-examples/kitchen-sink.mdx
+++ b/packages/site/pages/content-examples/kitchen-sink.mdx
@@ -7,7 +7,7 @@ action-1-text: Primary action
 action-1-link: /
 action-2-text: Secondary action
 action-2-link: /content-examples/kitchen-sink
-keywords: ['kitchen sink', 'introduction', 'simple']
+keywords: ['accessibility', 'introduction', 'simple']
 ---
 
 import {DoDontContainer, Do, Dont, Caption} from '@primer/doctocat-nextjs'

--- a/packages/site/pages/content-examples/simple.mdx
+++ b/packages/site/pages/content-examples/simple.mdx
@@ -1,6 +1,7 @@
 ---
 title: Simple
 description: A simple page with plain markdown
+keywords: ['kitchen sink', 'introduction', 'simple']
 ---
 
 ## Arva qua ferarum victa

--- a/packages/site/pages/getting-started/introduction.mdx
+++ b/packages/site/pages/getting-started/introduction.mdx
@@ -1,7 +1,8 @@
 ---
 title: Introduction
 description: Learn how to create a new site with Doctocat
-keywords: ['kitchen sink', 'introduction', 'simple']
+keywords: ['accessibility', 'introduction', 'simple']
+related: [{title: External link example, href: https://primer.style}]
 ---
 
 This guide will walk you through creating, customizing, and deploying a new documentation site powered by Doctocat on [Next.js](https://nextjs.org/).

--- a/packages/site/pages/getting-started/introduction.mdx
+++ b/packages/site/pages/getting-started/introduction.mdx
@@ -2,7 +2,6 @@
 title: Introduction
 description: Learn how to create a new site with Doctocat
 keywords: ['accessibility', 'introduction', 'simple']
-related: [{title: External link example, href: https://primer.style}]
 ---
 
 This guide will walk you through creating, customizing, and deploying a new documentation site powered by Doctocat on [Next.js](https://nextjs.org/).

--- a/packages/site/pages/getting-started/introduction.mdx
+++ b/packages/site/pages/getting-started/introduction.mdx
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 description: Learn how to create a new site with Doctocat
+keywords: ['kitchen sink', 'introduction', 'simple']
 ---
 
 This guide will walk you through creating, customizing, and deploying a new documentation site powered by Doctocat on [Next.js](https://nextjs.org/).

--- a/packages/theme/components/layout/header/Header.tsx
+++ b/packages/theme/components/layout/header/Header.tsx
@@ -163,7 +163,11 @@ export function Header({pageMap, docsDirectories, siteTitle}: HeaderProps) {
   }, [])
 
   return (
-    <nav className={clsx(styles.Header, isSearchOpen && styles['Header--searchAreaOpen'])}>
+    <nav
+      className={clsx(styles.Header, isSearchOpen && styles['Header--searchAreaOpen'])}
+      role="navigation"
+      aria-label="Header Navigation"
+    >
       <Link href="/" className={styles.Header__siteTitle}>
         <MarkGithubIcon size={24} />
         <Text as="p" size="300" weight="semibold">

--- a/packages/theme/components/layout/related-content-links/RelatedContentLinks.module.css
+++ b/packages/theme/components/layout/related-content-links/RelatedContentLinks.module.css
@@ -1,4 +1,5 @@
 .wrapper {
+  width: 220px;
 }
 
 .heading {

--- a/packages/theme/components/layout/related-content-links/RelatedContentLinks.module.css
+++ b/packages/theme/components/layout/related-content-links/RelatedContentLinks.module.css
@@ -1,15 +1,4 @@
-.wrapper {
-  width: 220px;
-}
-
-.heading {
-  font-size: var(--base-size-12);
-  padding-inline-start: var(--base-size-16);
-  margin-block-end: var(--base-size-8);
-  text-transform: uppercase;
-}
-
-.item {
-  margin-block-end: var(--base-size-4);
-  transition: transform var(--brand-animation-duration-fast) var(--brand-animation-easing-default);
+.list {
+  margin-block: var(--base-size-24);
+  margin-inline-start: 0 !important;
 }

--- a/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
+++ b/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {NavList} from '@primer/react'
-import {Text} from '@primer/react-brand'
+import {Text, Heading, UnorderedList, InlineLink} from '@primer/react-brand'
 import {MdxFile} from 'nextra'
 
 import styles from './RelatedContentLinks.module.css'
@@ -19,37 +19,16 @@ export function RelatedContentLinks({links}: RelatedContentLinksProps) {
   if (!links.length) return null
 
   return (
-    <aside className={styles.wrapper}>
-      <Text as="p" size="100" variant="muted" weight="normal" className={styles.heading}>
-        Related content
-      </Text>
-      <NavList aria-label="Related content">
+    <div className="custom-component">
+      <Heading as="h2">Related content</Heading>
+      <UnorderedList className={styles.list}>
         {links.map(page => (
-          <NavItem
-            className={styles.item}
-            key={page.title}
-            id={`toc-page-${page.route.replace(/\//g, '-')}`}
-            href={page.route}
-          >
-            {page.title}
-          </NavItem>
+          <UnorderedList.Item key={page.route}>
+            <InlineLink href={page.route}>{page.title}</InlineLink>{' '}
+            {page.route.startsWith('http') ? <LinkExternalIcon /> : null}
+          </UnorderedList.Item>
         ))}
-      </NavList>
-    </aside>
-  )
-}
-
-function NavItem({href, children, ...rest}) {
-  return (
-    <Link href={href} legacyBehavior passHref {...rest}>
-      <NavList.Item>
-        {children}{' '}
-        {href.startsWith('http') ? (
-          <NavList.TrailingVisual>
-            <LinkExternalIcon />
-          </NavList.TrailingVisual>
-        ) : null}
-      </NavList.Item>
-    </Link>
+      </UnorderedList>
+    </div>
   )
 }

--- a/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
+++ b/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import {NavList} from '@primer/react'
+import {Text} from '@primer/react-brand'
+import {MdxFile} from 'nextra'
+
+import styles from './RelatedContentLinks.module.css'
+import Link from 'next/link'
+
+export type RelatedContentLink = MdxFile & {
+  title: string
+}
+
+export type RelatedContentLinksProps = {
+  links: RelatedContentLink[]
+}
+
+export function RelatedContentLinks({links}: RelatedContentLinksProps) {
+  if (!links.length) return null
+
+  return (
+    <aside className={styles.wrapper}>
+      <Text as="p" size="100" variant="muted" weight="normal" className={styles.heading}>
+        Related content
+      </Text>
+      <NavList>
+        {links.map(page => (
+          <NavItem
+            className={styles.item}
+            key={page.title}
+            id={`toc-page-${page.route.replace(/\//g, '-')}`}
+            href={page.route}
+          >
+            {page.title}
+          </NavItem>
+        ))}
+      </NavList>
+    </aside>
+  )
+}
+
+function NavItem({href, children, ...rest}) {
+  return (
+    <Link href={href} legacyBehavior passHref {...rest}>
+      <NavList.Item>{children}</NavList.Item>
+    </Link>
+  )
+}

--- a/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
+++ b/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
@@ -23,7 +23,7 @@ export function RelatedContentLinks({links}: RelatedContentLinksProps) {
       <Text as="p" size="100" variant="muted" weight="normal" className={styles.heading}>
         Related content
       </Text>
-      <NavList>
+      <NavList aria-label="Related content">
         {links.map(page => (
           <NavItem
             className={styles.item}

--- a/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
+++ b/packages/theme/components/layout/related-content-links/RelatedContentLinks.tsx
@@ -5,6 +5,7 @@ import {MdxFile} from 'nextra'
 
 import styles from './RelatedContentLinks.module.css'
 import Link from 'next/link'
+import {LinkExternalIcon} from '@primer/octicons-react'
 
 export type RelatedContentLink = MdxFile & {
   title: string
@@ -41,7 +42,14 @@ export function RelatedContentLinks({links}: RelatedContentLinksProps) {
 function NavItem({href, children, ...rest}) {
   return (
     <Link href={href} legacyBehavior passHref {...rest}>
-      <NavList.Item>{children}</NavList.Item>
+      <NavList.Item>
+        {children}{' '}
+        {href.startsWith('http') ? (
+          <NavList.TrailingVisual>
+            <LinkExternalIcon />
+          </NavList.TrailingVisual>
+        ) : null}
+      </NavList.Item>
     </Link>
   )
 }

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -273,7 +273,7 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
                     </div>
                   </PageLayout.Content>
                   <PageLayout.Pane
-                    aria-label="Sticky pane"
+                    aria-label="Side navigation"
                     width="small"
                     sticky
                     padding="none"

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -122,12 +122,9 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
             <Head>
               <title>{title}</title>
               {frontMatter.description && <meta name="description" content={frontMatter.description} />}
-
-              <meta property="og:url" content={`https://brand.github.com${route}`} />
               <meta property="og:type" content="website" />
               <meta property="og:title" content={title} />
               {frontMatter.description && <meta property="og:description" content={frontMatter.description} />}
-
               <meta
                 property="og:image"
                 content={
@@ -135,11 +132,8 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
                   'https://github.com/primer/brand/assets/19292210/8562a9a5-a1e4-4722-9ec7-47ebccd5901e'
                 }
               />
-
               {/* X (Twitter) OG */}
               <meta name="twitter:card" content="summary_large_image" />
-              <meta property="twitter:domain" content="brand.github.com" />
-              <meta property="twitter:url" content={`https://brand.github.com${route}`} />
               <meta name="twitter:title" content={title} />
               {frontMatter.description && <meta name="twitter:description" content={frontMatter.description} />}
               <meta

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -125,7 +125,7 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
 
               <meta property="og:url" content={`https://brand.github.com${route}`} />
               <meta property="og:type" content="website" />
-              <meta property="og:title" content="GitHub Brand Guide" />
+              <meta property="og:title" content={title} />
               {frontMatter.description && <meta property="og:description" content={frontMatter.description} />}
 
               <meta

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -121,7 +121,34 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
           <BaseStyles>
             <Head>
               <title>{title}</title>
-              <meta name="og:image" content={frontMatter.image} />
+              {frontMatter.description && <meta name="description" content={frontMatter.description} />}
+
+              <meta property="og:url" content={`https://brand.github.com${route}`} />
+              <meta property="og:type" content="website" />
+              <meta property="og:title" content="GitHub Brand Guide" />
+              {frontMatter.description && <meta property="og:description" content={frontMatter.description} />}
+
+              <meta
+                property="og:image"
+                content={
+                  frontMatter.image ||
+                  'https://github.com/primer/brand/assets/19292210/8562a9a5-a1e4-4722-9ec7-47ebccd5901e'
+                }
+              />
+
+              {/* X (Twitter) OG */}
+              <meta name="twitter:card" content="summary_large_image" />
+              <meta property="twitter:domain" content="brand.github.com" />
+              <meta property="twitter:url" content={`https://brand.github.com${route}`} />
+              <meta name="twitter:title" content={title} />
+              {frontMatter.description && <meta name="twitter:description" content={frontMatter.description} />}
+              <meta
+                name="twitter:image"
+                content={
+                  frontMatter.image ||
+                  'https://github.com/primer/brand/assets/19292210/8562a9a5-a1e4-4722-9ec7-47ebccd5901e'
+                }
+              />
             </Head>
             <AnimationProvider runOnce visibilityOptions={1} autoStaggerChildren={false}>
               <Animate animate="fade-in">

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -142,7 +142,7 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
                 </PRCBox>
                 <PageLayout rowGap="none" columnGap="none" padding="none" containerWidth="full">
                   <PageLayout.Content padding="normal">
-                    <main id="main">
+                    <div id="main">
                       <PRCBox sx={!isHomePage && {display: 'flex', maxWidth: 1600, margin: '0 auto'}}>
                         <PRCBox sx={!isHomePage && {maxWidth: 800, width: '100%', margin: '0 auto'}}>
                           <Stack direction="vertical" padding="none" gap="spacious">
@@ -270,7 +270,7 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
                           </PRCBox>
                         </PRCBox>
                       </PRCBox>
-                    </main>
+                    </div>
                   </PageLayout.Content>
                   <PageLayout.Pane
                     aria-label="Sticky pane"

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -36,6 +36,7 @@ import {IndexCards} from '../index-cards/IndexCards'
 import {useColorMode} from '../../context/color-modes/useColorMode'
 import {getComponents} from '../../mdx-components/mdx-components'
 import {SkipToMainContent} from '../skip-to-main-content/SkipToMainContent'
+import {RelatedContentLink, RelatedContentLinks} from '../related-content-links/RelatedContentLinks'
 
 const {publicRuntimeConfig} = getConfig()
 
@@ -63,6 +64,31 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
     data && data.kind === 'Folder'
       ? ((data as Folder).children.filter(child => child.kind === 'MdxPage') as MdxFile[])
       : []
+
+  /**
+   * Uses a frontmatter 'keywords' value (as an array)
+   * to find adjacent pages that share the same values.
+   * @returns {RelatedContentLink[]}
+   */
+  const getRelatedPages = () => {
+    const currentPageKeywords = frontMatter.keywords || []
+    const matches: RelatedContentLink[] = []
+
+    for (const page of flatDocsDirectories) {
+      if (page.route === route) continue
+
+      if ('frontMatter' in page) {
+        const pageKeywords = page.frontMatter?.keywords || []
+        const intersection = pageKeywords.filter(keyword => currentPageKeywords.includes(keyword))
+
+        if (intersection.length) {
+          matches.push(page)
+        }
+      }
+    }
+
+    return matches
+  }
 
   return (
     <>
@@ -203,11 +229,22 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
                             </footer>
                           </Stack>
                         </PRCBox>
-                        {!isHomePage && headings.length > 0 && (
-                          <PRCBox sx={{py: 2, pr: 3, display: ['none', null, null, null, 'block']}}>
-                            <TableOfContents headings={headings} />
+                        <PRCBox sx={{py: 2, pr: 3, display: ['none', null, null, null, 'block']}}>
+                          <PRCBox
+                            sx={{
+                              position: 'sticky',
+                              top: 112,
+                              width: 220,
+                            }}
+                          >
+                            {!isHomePage && headings.length > 0 && <TableOfContents headings={headings} />}
+                            {getRelatedPages().length > 0 && (
+                              <PRCBox sx={{pt: 5}}>
+                                <RelatedContentLinks links={getRelatedPages()} />
+                              </PRCBox>
+                            )}
                           </PRCBox>
-                        )}
+                        </PRCBox>
                       </PRCBox>
                     </main>
                   </PageLayout.Content>

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -72,8 +72,10 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
    */
   const getRelatedPages = () => {
     const currentPageKeywords = frontMatter.keywords || []
+    const relatedLinks = frontMatter['related'] || []
     const matches: RelatedContentLink[] = []
 
+    // 1. Check keywords property and find local matches
     for (const page of flatDocsDirectories) {
       if (page.route === route) continue
 
@@ -84,6 +86,28 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
         if (intersection.length) {
           matches.push(page)
         }
+      }
+    }
+
+    // 2. Check related property for internal and external links
+    for (const link of relatedLinks) {
+      if (!link.title || !link.href || link.href === route) continue
+
+      if (link.href.startsWith('/')) {
+        const page = flatDocsDirectories.find(localPage => localPage.route === link.href) as
+          | RelatedContentLink
+          | undefined
+
+        if (page) {
+          const entry = {
+            ...page,
+            title: link.title || page.title,
+            route: link.href || page.route,
+          }
+          matches.push(entry)
+        }
+      } else {
+        matches.push({...link, route: link.href})
       }
     }
 

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -247,7 +247,14 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
                               {isIndexPage ? (
                                 <IndexCards folderData={flatDocsDirectories} route={route} />
                               ) : (
-                                <MDXProvider components={getComponents()}>{children}</MDXProvider>
+                                <>
+                                  <MDXProvider components={getComponents()}>{children}</MDXProvider>
+                                  {getRelatedPages().length > 0 && (
+                                    <PRCBox sx={{pt: 5}}>
+                                      <RelatedContentLinks links={getRelatedPages()} />
+                                    </PRCBox>
+                                  )}
+                                </>
                               )}
                             </article>
                             <footer>
@@ -289,11 +296,6 @@ export function Theme({children, pageOpts}: NextraThemeLayoutProps) {
                             }}
                           >
                             {!isHomePage && headings.length > 0 && <TableOfContents headings={headings} />}
-                            {getRelatedPages().length > 0 && (
-                              <PRCBox sx={{pt: 5}}>
-                                <RelatedContentLinks links={getRelatedPages()} />
-                              </PRCBox>
-                            )}
                           </PRCBox>
                         </PRCBox>
                       </PRCBox>

--- a/packages/theme/components/layout/sidebar/Sidebar.tsx
+++ b/packages/theme/components/layout/sidebar/Sidebar.tsx
@@ -55,7 +55,7 @@ export function Sidebar({pageMap}: SidebarProps) {
 
   return (
     <div className={styles.Sidebar}>
-      <NavList className={styles.NavList}>
+      <NavList className={styles.NavList} aria-label="Menu links">
         {reorderedPageMap.map(item => {
           if (item.kind === 'MdxPage' && item.route === '/') return null
 

--- a/packages/theme/components/layout/table-of-contents/TableOfContents.module.css
+++ b/packages/theme/components/layout/table-of-contents/TableOfContents.module.css
@@ -1,6 +1,3 @@
-.wrapper {
-}
-
 .heading {
   font-size: var(--base-size-12);
   padding-inline-start: var(--base-size-16);
@@ -11,4 +8,8 @@
 .item {
   margin-block-end: var(--base-size-4);
   transition: transform var(--brand-animation-duration-fast) var(--brand-animation-easing-default);
+}
+
+.item[aria-current='location'] {
+  transform: translateX(var(--base-size-4));
 }

--- a/packages/theme/components/layout/table-of-contents/TableOfContents.tsx
+++ b/packages/theme/components/layout/table-of-contents/TableOfContents.tsx
@@ -61,7 +61,7 @@ export function TableOfContents({headings}: TableOfContentsProps) {
       <Text as="p" size="100" variant="muted" weight="normal" className={styles.heading}>
         On this page
       </Text>
-      <NavList>
+      <NavList aria-label="Table of contents">
         {depth2Headings.map(heading => (
           <NavList.Item
             className={styles.item}


### PR DESCRIPTION
Adds feature to enable related content through Markdown front matter. 

🔗  [Try it here](https://primer-43c18de058-41738341.drafts.github.io/getting-started/introduction)

### How it works

Related content links appear on all content pages, except the homepage. They are located beneath the main content.

The links are generated through a combination of `keywords` and `related` links for maximum flexibility and catchment of content, all of is are managed via the Markdown files frontmatter.

#### Non-specific keywords
The easiest way to link pages is through sharing related keywords. E.g. `accessibility`, `branding` etc.

The technical approach works by reading the optional `keyword` property in front matter, and finding matches in adjacent pages. If matches are found, a `Related content` navigation menu will appear beneath the main content.

#### Specific links

For scenario's wher fine-grained control is required for cross-linking, such as external links or custom labels, a `related` key is also available which accepts a more verbose `Object` type. 

🔗  [See this Markdown example](https://github.com/primer/doctocat-nextjs/pull/8/files#diff-9ab86ea8daaaa86e1dfa619cf7e106269bbcecabf02bcef8b3799ef610b0512eR4-R5)

### Screenshot

![Screenshot 2024-01-16 at 17 47 56](https://github.com/primer/doctocat-nextjs/assets/13340707/0bd5f7a8-9b1f-471a-8a72-0f3673e39e16)

