### PR TITLE
Correct size of site title in Header

### DIFF
--- a/packages/theme/components/layout/header/Header.tsx
+++ b/packages/theme/components/layout/header/Header.tsx
@@ -60,7 +60,7 @@ export function Header({siteTitle, flatDocsDirectories, pageMap}: HeaderProps) {
       <div className={styles.Header__start}>
         <Link href="/" className={styles.Header__siteTitle}>
           <MarkGithubIcon size={24} />
-          <Text className={styles.Header__siteTitleText} as="p" size="300" weight="semibold">
+          <Text className={styles.Header__siteTitleText} as="p" size="200" weight="semibold">
             {siteTitle}
           </Text>
         </Link>


### PR DESCRIPTION
https://primer.style/product/ uses 16px, which Doctocat now matches