### PR TITLE
Enable support for Next.js trailingSlash config

### DIFF
--- a/.changeset/many-spiders-repair.md
+++ b/.changeset/many-spiders-repair.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Enable support for `trailingSlash: true` in `next.config.js`

--- a/packages/site/next.config.ts
+++ b/packages/site/next.config.ts
@@ -6,6 +6,5 @@ export default {
     transpilePackages: ['@primer/doctocat-nextjs'],
     output: 'export',
     basePath: process.env.GITHUB_ACTIONS === 'true' && process.env.IS_PROD ? '/doctocat-nextjs' : '',
-    trailingSlash: true,
   }),
 }

--- a/packages/site/next.config.ts
+++ b/packages/site/next.config.ts
@@ -6,5 +6,6 @@ export default {
     transpilePackages: ['@primer/doctocat-nextjs'],
     output: 'export',
     basePath: process.env.GITHUB_ACTIONS === 'true' && process.env.IS_PROD ? '/doctocat-nextjs' : '',
+    trailingSlash: true,
   }),
 }

--- a/packages/theme/components/layout/index-cards/IndexCards.tsx
+++ b/packages/theme/components/layout/index-cards/IndexCards.tsx
@@ -12,12 +12,21 @@ type IndexCardsProps = {
 
 export function IndexCards({route, folderData}: IndexCardsProps) {
   // We don't want to show children of these pages. E.g. tabbed pages
-  const onlyDirectChildren = folderData.filter(
-    item => item.route.includes(`${route}/`) && item.route.split('/').length === 3,
-  )
+  const onlyDirectChildren = folderData.filter(item => {
+    // Normalize paths regardless of trailing slash enablement
+    const normalizedRoute = route.endsWith('/') ? route : `${route}/`
+    const normalizedItemRoute = item.route.endsWith('/') ? item.route : `${item.route}/`
 
-  const filteredData = onlyDirectChildren.filter(item => item.type === 'doc' && item.route.includes(`${route}/`))
+    const isChild = normalizedItemRoute.startsWith(normalizedRoute)
+    if (!isChild) return false
 
+    const routeSegments = normalizedRoute.split('/').filter(Boolean).length
+    const itemSegments = normalizedItemRoute.split('/').filter(Boolean).length
+
+    return itemSegments === routeSegments + 1
+  })
+
+  const filteredData = onlyDirectChildren.filter(item => item.type === 'doc')
   return (
     <Stack direction="vertical" padding="none" gap="spacious">
       {filteredData.map((item: DocsItem) => {

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -53,15 +53,12 @@ export type ThemeProps = PropsWithChildren<{
 
 export function Theme({pageMap, children}: ThemeProps) {
   const pathname = usePathname()
+  const pathHasTrailingSlash = pathname.endsWith('/')
 
   const normalizedPages = normalizePages({
     list: pageMap,
     route: pathname,
   })
-
-  const {activeMetadata} = normalizedPages
-
-  const {filePath = '', title = ''} = activeMetadata || {}
 
   const route = usePathname()
 
@@ -79,6 +76,14 @@ export function Theme({pageMap, children}: ThemeProps) {
   // eslint-disable-next-line i18n-text/no-en
   const siteTitle = process.env.NEXT_PUBLIC_SITE_TITLE || 'Example Site'
   const isHomePage = route === '/'
+
+  const {frontMatter: activeMetadata} = isHomePage
+    ? {}
+    : (normalizedPages.flatDocsDirectories.find(
+        item => `${item.route}${pathHasTrailingSlash ? '/' : ''}` === pathname,
+      ) as MdxFile)
+
+  const {filePath = '', title = ''} = activeMetadata || {}
   const isIndexPage =
     /index\.mdx?$/.test(filePath) && !isHomePage && activeMetadata && activeMetadata['show-tabs'] === undefined
   const data = !isHomePage && activePath[activePath.length - 2]
@@ -86,6 +91,7 @@ export function Theme({pageMap, children}: ThemeProps) {
 
   const relatedLinks = getRelatedPages(route, activeMetadata, flatDocsDirectories)
   const disablePageAnimation = activeMetadata?.options?.disablePageAnimation || false
+
   return (
     <>
       <BrandThemeProvider dir="ltr" colorMode={colorMode}>

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -92,7 +92,7 @@ export function Theme({pageMap, children}: ThemeProps) {
   const filteredTabData: MdxFile[] = data && hasChildren(data) ? ((data as Folder).children as MdxFile[]) : []
 
   const relatedLinks = getRelatedPages(route, activeMetadata, flatDocsDirectories)
-  const disablePageAnimation = activeMetadata?.options?.disablePageAnimation || false
+  const disablePageAnimation = activeMetadata.options?.disablePageAnimation || false
 
   return (
     <>
@@ -165,22 +165,22 @@ export function Theme({pageMap, children}: ThemeProps) {
 
                             <Box>
                               <Stack direction="vertical" padding="none" gap={12} alignItems="flex-start">
-                                {activeMetadata?.title && (
+                                {activeMetadata.title && (
                                   <Heading as="h1" size="3">
                                     {activeMetadata.title}
                                   </Heading>
                                 )}
-                                {activeMetadata?.description && (
+                                {activeMetadata.description && (
                                   <Text as="p" variant="muted" size="300">
                                     {activeMetadata.description}
                                   </Text>
                                 )}
-                                {activeMetadata?.image && (
+                                {activeMetadata.image && (
                                   <Box paddingBlockStart={16} style={{width: '100%'}}>
                                     <Hero.Image src={activeMetadata.image} alt={activeMetadata['image-alt']} />
                                   </Box>
                                 )}
-                                {activeMetadata && activeMetadata['action-1-text'] && (
+                                {activeMetadata['action-1-text'] && (
                                   <Box paddingBlockStart={16}>
                                     <ButtonGroup>
                                       <Button as="a" href={activeMetadata['action-1-link']}>
@@ -196,9 +196,7 @@ export function Theme({pageMap, children}: ThemeProps) {
                                 )}
                               </Stack>
                             </Box>
-                            {activeMetadata && activeMetadata['show-tabs'] && (
-                              <UnderlineNav tabData={filteredTabData} />
-                            )}
+                            {activeMetadata['show-tabs'] && <UnderlineNav tabData={filteredTabData} />}
                           </>
                         )}
                         <article>

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -77,15 +77,17 @@ export function Theme({pageMap, children}: ThemeProps) {
   const siteTitle = process.env.NEXT_PUBLIC_SITE_TITLE || 'Example Site'
   const isHomePage = route === '/'
 
-  const {frontMatter: activeMetadata} = isHomePage
-    ? {}
+  const activeFile = isHomePage
+    ? undefined
     : (normalizedPages.flatDocsDirectories.find(
         item => `${item.route}${pathHasTrailingSlash ? '/' : ''}` === pathname,
       ) as MdxFile)
 
-  const {filePath = '', title = ''} = activeMetadata || {}
-  const isIndexPage =
-    /index\.mdx?$/.test(filePath) && !isHomePage && activeMetadata && activeMetadata['show-tabs'] === undefined
+  const activeMetadata = activeFile?.frontMatter || {}
+  const filePath = activeMetadata.filePath || ''
+  const title = activeMetadata.title || ''
+
+  const isIndexPage = /index\.mdx?$/.test(filePath) && !isHomePage && activeMetadata['show-tabs'] === undefined
   const data = !isHomePage && activePath[activePath.length - 2]
   const filteredTabData: MdxFile[] = data && hasChildren(data) ? ((data as Folder).children as MdxFile[]) : []
 
@@ -97,21 +99,19 @@ export function Theme({pageMap, children}: ThemeProps) {
       <BrandThemeProvider dir="ltr" colorMode={colorMode}>
         <ThemeProvider colorMode={colorMode}>
           <BaseStyles>
-            {activeMetadata && (
-              <Head>
-                <title>{title}</title>
-                {activeMetadata.description && <meta name="description" content={activeMetadata.description} />}
-                <meta property="og:type" content="website" />
-                <meta property="og:title" content={title} />
-                {activeMetadata.description && <meta property="og:description" content={activeMetadata.description} />}
-                <meta property="og:image" content={activeMetadata.image || '/og-image.png'} />
-                {/* X (Twitter) OG */}
-                <meta name="twitter:card" content="summary_large_image" />
-                <meta name="twitter:title" content={title} />
-                {activeMetadata.description && <meta name="twitter:description" content={activeMetadata.description} />}
-                <meta name="twitter:image" content={activeMetadata.image || '/og-image.png'} />
-              </Head>
-            )}
+            <Head>
+              <title>{title}</title>
+              {activeMetadata.description && <meta name="description" content={activeMetadata.description} />}
+              <meta property="og:type" content="website" />
+              <meta property="og:title" content={title} />
+              {activeMetadata.description && <meta property="og:description" content={activeMetadata.description} />}
+              <meta property="og:image" content={activeMetadata.image || '/og-image.png'} />
+              {/* X (Twitter) OG */}
+              <meta name="twitter:card" content="summary_large_image" />
+              <meta name="twitter:title" content={title} />
+              {activeMetadata.description && <meta name="twitter:description" content={activeMetadata.description} />}
+              <meta name="twitter:image" content={activeMetadata.image || '/og-image.png'} />
+            </Head>
 
             <ContentWrapper disableAnimations={disablePageAnimation}>
               <PRCBox

--- a/packages/theme/components/layout/sidebar/Sidebar.tsx
+++ b/packages/theme/components/layout/sidebar/Sidebar.tsx
@@ -73,12 +73,13 @@ export function Sidebar({pageMap}: SidebarProps) {
                   if (!hasChildren(child)) {
                     const {name, route} = child as MdxFile
 
+                    const cleanPathname = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
                     return (
                       <NavList.Item
                         as={NextLink}
                         key={name}
                         href={route}
-                        aria-current={route === pathname ? 'page' : undefined}
+                        aria-current={route === cleanPathname ? 'page' : undefined}
                       >
                         {(child as MdxFile).frontMatter?.title || name}
                       </NavList.Item>
@@ -88,17 +89,29 @@ export function Sidebar({pageMap}: SidebarProps) {
                   if (hasChildren(child)) {
                     const landingPageItem = (child as Folder).children.find(
                       innerChild => (innerChild as DocsItem).name === 'index',
-                    )
+                    ) as MdxFile
+
+                    const normalizePath = (path: string) => {
+                      // Remove trailing slash unless it's the root path
+                      return path === '/' ? path : path.replace(/\/+$/, '')
+                    }
+
+                    // Then inside your component where you need to compare paths:
+                    const cleanPathname = normalizePath(pathname)
+                    const cleanRoute = normalizePath(landingPageItem.route)
+
+                    // For checking if current path is this route or a direct child:
+                    const isCurrentOrChild = cleanPathname === cleanRoute || cleanPathname.startsWith(`${cleanRoute}/`)
 
                     return (
                       <NavList.Item
                         as={NextLink}
-                        key={(landingPageItem as MdxFile).route}
-                        href={(landingPageItem as MdxFile).route}
+                        key={landingPageItem.route}
+                        href={landingPageItem.route}
                         sx={{textTransform: 'capitalize'}}
-                        aria-current={(landingPageItem as MdxFile).route === pathname ? 'page' : undefined}
+                        aria-current={isCurrentOrChild ? 'page' : undefined}
                       >
-                        {(landingPageItem as MdxFile).frontMatter?.title || item.name}
+                        {landingPageItem.frontMatter?.title || item.name}
                       </NavList.Item>
                     )
                   }

--- a/packages/theme/components/layout/sidebar/Sidebar.tsx
+++ b/packages/theme/components/layout/sidebar/Sidebar.tsx
@@ -63,6 +63,11 @@ export function Sidebar({pageMap}: SidebarProps) {
             )
           }
 
+          const normalizePath = (path: string) => {
+            // Remove trailing slash unless it's the root path
+            return path === '/' ? path : path.replace(/\/+$/, '')
+          }
+
           return (
             <NavList.Group title={subNavName} key={item.name} sx={{mb: 24}}>
               {item.children
@@ -73,7 +78,7 @@ export function Sidebar({pageMap}: SidebarProps) {
                   if (!hasChildren(child)) {
                     const {name, route} = child as MdxFile
 
-                    const cleanPathname = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+                    const cleanPathname = normalizePath(pathname)
                     return (
                       <NavList.Item
                         as={NextLink}
@@ -90,11 +95,6 @@ export function Sidebar({pageMap}: SidebarProps) {
                     const landingPageItem = (child as Folder).children.find(
                       innerChild => (innerChild as DocsItem).name === 'index',
                     ) as MdxFile
-
-                    const normalizePath = (path: string) => {
-                      // Remove trailing slash unless it's the root path
-                      return path === '/' ? path : path.replace(/\/+$/, '')
-                    }
 
                     // Then inside your component where you need to compare paths:
                     const cleanPathname = normalizePath(pathname)

--- a/packages/theme/components/layout/underline-nav/UnderlineNav.tsx
+++ b/packages/theme/components/layout/underline-nav/UnderlineNav.tsx
@@ -33,7 +33,7 @@ export function UnderlineNav({tabData}: UnderlineNavProps) {
     <PrimerUnderlineNav aria-label="Sibling pages">
       {tabData.length > 1 &&
         tabData.reverse().map(item => {
-          const cleanPathname = pathHasTrailingSlash ? pathname.slice(0, -1) : pathname
+          const cleanPathname = pathname === '/' ? '/' : pathHasTrailingSlash ? pathname.slice(0, -1) : pathname
 
           return (
             <PrimerUnderlineNav.Item

--- a/packages/theme/components/layout/underline-nav/UnderlineNav.tsx
+++ b/packages/theme/components/layout/underline-nav/UnderlineNav.tsx
@@ -12,8 +12,7 @@ type UnderlineNavProps = {
 export function UnderlineNav({tabData}: UnderlineNavProps) {
   const [isClient, setIsClient] = useState(false)
   const pathname = usePathname()
-
-  const currentRoute = pathname
+  const pathHasTrailingSlash = pathname.endsWith('/')
 
   // Reorders tabData so the tab with name === index is always first
   if (tabData.length > 1) {
@@ -34,12 +33,14 @@ export function UnderlineNav({tabData}: UnderlineNavProps) {
     <PrimerUnderlineNav aria-label="Sibling pages">
       {tabData.length > 1 &&
         tabData.reverse().map(item => {
+          const cleanPathname = pathHasTrailingSlash ? pathname.slice(0, -1) : pathname
+
           return (
             <PrimerUnderlineNav.Item
               as={Link}
               key={item.name}
               href={`${item.route}`}
-              aria-current={currentRoute === item.route ? 'page' : undefined}
+              aria-current={cleanPathname === item.route ? 'page' : undefined}
             >
               {(item.frontMatter && (item.frontMatter['tab-label'] || item.frontMatter.title)) || item.name}
             </PrimerUnderlineNav.Item>

--- a/packages/theme/css/prose.module.css
+++ b/packages/theme/css/prose.module.css
@@ -150,6 +150,7 @@
 .Prose ul:not(:global(.custom-component) ul) {
   list-style-type: image;
   list-style-image: var(--brand-Prose-unorderedList-imageUrl);
+  margin-block-end: var(--base-size-24) !important;
 }
 
 .Prose li:not(:global(.custom-component) li) {


### PR DESCRIPTION
- Update logic using pathnames to account for an optional trailingSlash
- Fixes aria-current sidenav indicator on tabbed subpages
    
  <table>
  <tr>
  <th> Before</th> <th> After </th>
  </tr>
  <tr>
  <td valign="top">
  
  <!-- Insert "before" screenshot here -->
  <img width="484" alt="Screenshot 2025-05-05 at 16 02 35" src="https://github.com/user-attachments/assets/5310a2fe-12b1-491b-a0b8-0edb63f238eb" />
  
   </td>
  <td valign="top">
  
  <!-- Insert "after" screenshot here -->
  <img width="509" alt="Screenshot 2025-05-05 at 16 02 27" src="https://github.com/user-attachments/assets/53911dee-7c6a-4220-a1b8-f4ea1c6ae317" />
  
  </td>
  </tr>
  </table>
