### PR TITLE
Sidebar Updates

### DIFF
--- a/.changeset/afraid-roses-compete.md
+++ b/.changeset/afraid-roses-compete.md
@@ -1,0 +1,8 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+- Updated sidebar styles.
+- Added active header link as sidebar heading.
+- Made active header the root item of breadcrumbs, if available.
+- Made sidebar group headins link to the index page.

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -28,6 +28,8 @@ import '@primer/react-brand/lib/css/main.css'
 import {normalizePages} from 'nextra/normalize-pages'
 import {usePathname} from 'next/navigation'
 
+import {useConfig} from '../../context/useConfig'
+
 import {Header} from '../header/Header'
 import {IndexCards} from '../index-cards/IndexCards'
 import {useColorMode} from '../../context/color-modes/useColorMode'
@@ -75,6 +77,9 @@ export function Theme({pageMap, children}: ThemeProps) {
 
   // eslint-disable-next-line i18n-text/no-en
   const siteTitle = process.env.NEXT_PUBLIC_SITE_TITLE || 'Example Site'
+  const {headerLinks} = useConfig()
+  const activeHeaderLink = headerLinks.find(link => link.isActive)
+
   const isHomePage = route === '/'
 
   const activeFile = isHomePage
@@ -133,7 +138,7 @@ export function Theme({pageMap, children}: ThemeProps) {
                           <>
                             {activePath.length && (
                               <Breadcrumbs>
-                                {siteTitle && (
+                                {(activeHeaderLink || siteTitle) && (
                                   <Breadcrumbs.Item
                                     as={NextLink}
                                     href="/"
@@ -141,7 +146,7 @@ export function Theme({pageMap, children}: ThemeProps) {
                                       color: 'var(--brand-InlineLink-color-rest)',
                                     }}
                                   >
-                                    {siteTitle}
+                                    {activeHeaderLink ? activeHeaderLink.title : siteTitle}
                                   </Breadcrumbs.Item>
                                 )}
                                 {activePath.map((item, index) => {

--- a/packages/theme/components/layout/sidebar/Sidebar.module.css
+++ b/packages/theme/components/layout/sidebar/Sidebar.module.css
@@ -15,12 +15,8 @@
 }
 
 .NavList h3 {
-  font-weight: normal;
-  text-transform: uppercase;
-}
-
-.NavList [data-component='ActionList.Divider'] {
-  display: none; /* TODO: Find workaround to hide this in component */
+  color: var(--brand-color-text-default);
+  font-size: var(--brand-text-size-100);
 }
 
 .NavList__Container li a,

--- a/packages/theme/components/layout/sidebar/Sidebar.module.css
+++ b/packages/theme/components/layout/sidebar/Sidebar.module.css
@@ -1,3 +1,13 @@
+.Sidebar__title {
+  display: block;
+  padding: var(--base-size-24) var(--base-size-16) 0;
+}
+
+.NavList {
+  font-family: var(--brand-fontStack-sansSerif);
+  font-size: inherit;
+}
+
 @media (min-width: 768px) {
   .Sidebar {
     padding-inline-start: var(--base-size-8);
@@ -13,10 +23,17 @@
   display: none; /* TODO: Find workaround to hide this in component */
 }
 
-.NavList h3 {
-  text-transform: initial;
-  color: var(--brand-color-text-default);
-  font-weight: var(--brand-text-subhead-weight-medium);
-  font-size: var(--brand-text-subhead-size-medium);
-  line-height: var(--brand-text-subhead-lineHeight-medium);
+.NavList__Container li a,
+.NavList__Container li button {
+  font-size: var(--brand-text-size-200);
+  padding-block: 0.5em;
+}
+
+.NavList .NavListItem {
+  margin-top: var(--base-size-4);
+}
+
+.NavList .NavListItem,
+.NavList .NavListItem a {
+  font-size: inherit;
 }

--- a/packages/theme/components/layout/sidebar/Sidebar.tsx
+++ b/packages/theme/components/layout/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react'
 import NextLink from 'next/link'
 import {NavList} from '@primer/react'
+import {Text} from '@primer/react-brand'
 import type {Folder, MdxFile, PageMapItem} from 'nextra'
 
 import styles from './Sidebar.module.css'
@@ -20,7 +21,8 @@ type SidebarProps = {
 
 export function Sidebar({pageMap}: SidebarProps) {
   const pathname = usePathname()
-  const {sidebarLinks} = useConfig()
+  const {headerLinks, sidebarLinks} = useConfig()
+  const activeHeaderLink = headerLinks.find(link => link.isActive)
 
   /**
    * Sorts the incoming data so that folders with a menu-position frontmatter value
@@ -46,6 +48,12 @@ export function Sidebar({pageMap}: SidebarProps) {
 
   return (
     <div className={styles.Sidebar}>
+      {activeHeaderLink && (
+        <Text size="400" weight="semibold" className={styles.Sidebar__title}>
+          {activeHeaderLink.title}
+        </Text>
+      )}
+
       <NavList className={styles.NavList} aria-label="Menu links">
         {reorderedPageMap.map(item => {
           if (item.hasOwnProperty('data')) return null
@@ -85,6 +93,7 @@ export function Sidebar({pageMap}: SidebarProps) {
                         key={name}
                         href={route}
                         aria-current={route === cleanPathname ? 'page' : undefined}
+                        className={styles.NavListItem}
                       >
                         {(child as MdxFile).frontMatter?.title || name}
                       </NavList.Item>
@@ -110,6 +119,7 @@ export function Sidebar({pageMap}: SidebarProps) {
                         href={landingPageItem.route}
                         sx={{textTransform: 'capitalize'}}
                         aria-current={isCurrentOrChild ? 'page' : undefined}
+                        className={styles.NavListItem}
                       >
                         {landingPageItem.frontMatter?.title || item.name}
                       </NavList.Item>
@@ -129,6 +139,7 @@ export function Sidebar({pageMap}: SidebarProps) {
                   href={link.href}
                   {...(link.isExternal && {target: '_blank', rel: 'noopener noreferrer'})}
                   aria-current={link.isActive ? 'page' : undefined}
+                  className={styles.NavListItem}
                 >
                   {link.title}
                   {link.isExternal && (

--- a/packages/theme/components/layout/sidebar/Sidebar.tsx
+++ b/packages/theme/components/layout/sidebar/Sidebar.tsx
@@ -78,6 +78,9 @@ export function Sidebar({pageMap}: SidebarProps) {
 
           return (
             <NavList.Group title={subNavName} key={item.name} sx={{mb: 24}}>
+              <NavList.GroupHeading as="h3">
+                <NextLink href={item.route}>{subNavName}</NextLink>
+              </NavList.GroupHeading>
               {item.children
                 .sort((a, b) => ((a as MdxFile).name === 'index' ? -1 : (b as MdxFile).name === 'index' ? 1 : 0)) // puts index page first
                 // only show index page if it has show-tabs


### PR DESCRIPTION
- Adds the active link in the header as the sidebar title and the root item for breadcrumbs.
- Updates styles to match current primer.style
- Makes group headings link to the index page (now uses Mona Sans, update font sizes, visible dividers, ...)