### PR TITLE
Fixes for layout and pre styles

### DIFF
--- a/packages/theme/components/layout/article/Article.module.css
+++ b/packages/theme/components/layout/article/Article.module.css
@@ -1,5 +1,7 @@
 .Article {
   display: grid;
+  grid-template-areas: 'main aside';
+  grid-template-columns: 1fr 200px;
 }
 
 .Article--withToc {
@@ -7,36 +9,28 @@
 }
 
 .main {
-  order: 1;
+  grid-area: main;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .aside {
-  order: 0;
+  grid-area: aside;
+  position: relative;
 }
 
-@media screen and (max-width: 48rem) {
+@media screen and (max-width: 1023px) {
   .Article--withToc {
-    display: flex; /* Prevents column overflow */
-    flex-direction: column;
-  }
-}
-
-@media screen and (min-width: 1023px) {
-  .main {
-    order: 0;
-  }
-
-  .aside {
-    order: 1;
-  }
-
-  .Article--withToc {
-    grid-template-columns: 1fr 200px;
+    grid-template-areas:
+      'aside'
+      'main';
+    grid-template-columns: 1fr;
   }
 }
 
 @media screen and (min-width: 2048px) {
   .Article--withToc {
+    grid-template-areas: 'main';
     grid-template-columns: 1fr;
   }
 }

--- a/packages/theme/components/layout/article/Article.module.css
+++ b/packages/theme/components/layout/article/Article.module.css
@@ -1,11 +1,11 @@
 .Article {
   display: grid;
-  grid-template-areas: 'main aside';
-  grid-template-columns: 1fr 200px;
 }
 
 .Article--withToc {
   gap: var(--base-size-48);
+  grid-template-areas: 'main aside';
+  grid-template-columns: 1fr 200px;
 }
 
 .main {

--- a/packages/theme/components/layout/article/Article.module.css
+++ b/packages/theme/components/layout/article/Article.module.css
@@ -1,5 +1,7 @@
 .Article {
   display: grid;
+  grid-template-areas: 'main';
+  grid-template-columns: 1fr;
 }
 
 .Article--withToc {

--- a/packages/theme/components/layout/article/Article.module.css
+++ b/packages/theme/components/layout/article/Article.module.css
@@ -11,7 +11,7 @@
 .main {
   grid-area: main;
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 .aside {

--- a/packages/theme/components/layout/index-cards/IndexCards.tsx
+++ b/packages/theme/components/layout/index-cards/IndexCards.tsx
@@ -92,7 +92,7 @@ export function IndexCards({route, folderData}: IndexCardsProps) {
         return (
           <Grid.Column span={{xsmall: 12, small: 12, medium: 12, large: 6, xlarge: 4}} key={item.frontMatter.title}>
             <Link legacyBehavior passHref href={item.route}>
-              <Card href="#" hasBorder>
+              <Card href="#" hasBorder fullWidth>
                 <Card.Image src={thumbnailUrl} alt="" aspectRatio="4:3" />
                 <Card.Heading>{item.frontMatter.title}</Card.Heading>
                 {item.frontMatter.description && <Card.Description>{item.frontMatter.description}</Card.Description>}

--- a/packages/theme/components/layout/table-of-contents/TableOfContents.module.css
+++ b/packages/theme/components/layout/table-of-contents/TableOfContents.module.css
@@ -26,7 +26,6 @@
     display: flex;
     flex-direction: column;
     min-width: 280px;
-    right: 0;
     overflow: auto;
     padding: var(--base-size-40) var(--base-size-40) var(--base-size-40) 0;
     top: 65px;

--- a/packages/theme/css/global.css
+++ b/packages/theme/css/global.css
@@ -18,7 +18,8 @@ body {
   margin-block-start: 0 !important;
 }
 
-pre:not(:global(.CodeBlock) pre) {
+/* Pre styles are scoped to Nextra code blocks to prevent unintended styling of other code blocks (e.g., ReactCodeBlock previews). */
+.nextra-code pre {
   background-color: var(--brand-color-canvas-subtle);
   border-radius: var(--brand-borderRadius-large);
   padding-top: 1rem;

--- a/packages/theme/css/global.css
+++ b/packages/theme/css/global.css
@@ -18,7 +18,7 @@ body {
   margin-block-start: 0 !important;
 }
 
-pre {
+pre:not(:global(.CodeBlock) pre) {
   background-color: var(--brand-color-canvas-subtle);
   border-radius: var(--brand-borderRadius-large);
   padding-top: 1rem;


### PR DESCRIPTION
- Updates the `.Article` grid layout to prevent horizontal scrolling.

https://github.com/user-attachments/assets/dcfa7aa6-7024-403f-ad13-379f1331d2cf

- Scopes global `pre` styles to `nextra-code` to stop styles from leaking into ReactCodeBlock previews. Closes https://github.com/primer/brand/issues/1058

| Before | After |
|--------|--------|
| ![screenshot-4YeYvPoo-000260@2x](https://github.com/user-attachments/assets/590baa7d-92a3-4855-a249-5bbce1e28641)  | ![screenshot-xCCxXqso-000259@2x](https://github.com/user-attachments/assets/454fc7f0-46cc-4bc1-baaa-27b821e48fba) | 

- Makes index cards full-width for a bore balanced layout on narrow viewports

| Before | After |
|-----|-----|
| ![screenshot-2ktLfPyi-000265@2x](https://github.com/user-attachments/assets/4246d337-1e13-4e08-a32f-09e08ed322f8) | ![screenshot-ppRrYSNH-000266@2x](https://github.com/user-attachments/assets/91bf320e-cc34-40c9-95db-79c17af39dc0) |

