### PR TITLE
Fix inline code font size in headings

### DIFF
--- a/.changeset/khaki-mugs-cover.md
+++ b/.changeset/khaki-mugs-cover.md
@@ -1,0 +1,6 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+- Fix inline code font-size in markdown headings. Now inherits size used in the heading.
+- Increased spacing below React code blocks, which was previously too small.

--- a/packages/site/content/content-example/kitchen-sink.mdx
+++ b/packages/site/content/content-example/kitchen-sink.mdx
@@ -115,3 +115,7 @@ flowchart LR
   <Grid.Column span={2}></Grid.Column>
 </Grid>
 ```
+
+## Heading with `inline code`
+
+This heading has an inline code element in it. The code will be displayed at the same font size as the regular text.

--- a/packages/theme/components/layout/code-block/ReactCodeBlock.module.css
+++ b/packages/theme/components/layout/code-block/ReactCodeBlock.module.css
@@ -1,4 +1,5 @@
 .CodeBlock {
+  --spacing: var(--base-size-40);
   margin-block: var(--base-size-24);
   background-color: var(--brand-color-canvas-default);
   border: var(--brand-borderWidth-thin) solid var(--brand-color-border-default);

--- a/packages/theme/css/prose.module.css
+++ b/packages/theme/css/prose.module.css
@@ -211,6 +211,11 @@
   background-color: var(--base-color-scale-indigo-0);
 }
 
+/* Inline code inside headings should inherit font-size */
+.Prose :is(h1, h2, h3, h4, h5, h6):has(code) code:not(:global(.custom-component) code) {
+  font-size: inherit;
+}
+
 [data-color-mode='dark'] .Prose code:not(:global(.custom-component) code) {
   background-color: var(--base-color-scale-indigo-9);
 }


### PR DESCRIPTION
<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![Screenshot 2025-06-24 at 17 57 24](https://github.com/user-attachments/assets/33353051-9aff-4672-9c8c-65d38d96ca79)

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->
![Screenshot 2025-06-24 at 17 57 28](https://github.com/user-attachments/assets/cecd3fcb-9cc1-458b-aaae-f85658677d62)

</td>
</tr>
</table>


<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


![Screenshot 2025-06-24 at 17 56 55](https://github.com/user-attachments/assets/46fb69b3-936f-4c10-a72f-be46580159ae)

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

![Screenshot 2025-06-24 at 17 57 00](https://github.com/user-attachments/assets/d498b017-0a72-47b4-9bd1-7c0882a84ba0)
<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
