### PR TITLE
Add menu-position support for sidebar links

### DIFF
--- a/.changeset/real-pumas-boil.md
+++ b/.changeset/real-pumas-boil.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Add `menu-position` frontmatter support for custom sidebar navigation ordering

--- a/packages/site/content/content-example/simple.mdx
+++ b/packages/site/content/content-example/simple.mdx
@@ -7,6 +7,7 @@ related:
     href: 'https://primer.style/foundations/typography'
   - title: 'Monaspace'
     href: 'https://monaspace.githubnext.com/'
+menu-position: 1
 ---
 
 ## Arva qua ferarum victa

--- a/packages/theme/components/layout/sidebar/Sidebar.tsx
+++ b/packages/theme/components/layout/sidebar/Sidebar.tsx
@@ -82,7 +82,29 @@ export function Sidebar({pageMap}: SidebarProps) {
                 <NextLink href={item.route}>{subNavName}</NextLink>
               </NavList.GroupHeading>
               {item.children
-                .sort((a, b) => ((a as MdxFile).name === 'index' ? -1 : (b as MdxFile).name === 'index' ? 1 : 0)) // puts index page first
+                .sort((a, b) => {
+                  // make sure index page is first
+                  if ((a as MdxFile).name === 'index') return -1
+                  if ((b as MdxFile).name === 'index') return 1
+
+                  // Check for menu-position property in frontmatter
+                  const aPos = (a as MdxFile).frontMatter?.['menu-position']
+                  const bPos = (b as MdxFile).frontMatter?.['menu-position']
+
+                  // If both have menu-position, sort by menu-position
+                  if (typeof aPos === 'number' && typeof bPos === 'number') {
+                    return aPos - bPos
+                  }
+
+                  // If only one has menu-position, it comes first
+                  if (typeof aPos === 'number') return -1
+                  if (typeof bPos === 'number') return 1
+
+                  // Neither has menu-position, sort alphabetically by title or name
+                  const aTitle = (a as MdxFile).frontMatter?.title || (a as MdxFile).name
+                  const bTitle = (b as MdxFile).frontMatter?.title || (b as MdxFile).name
+                  return aTitle.localeCompare(bTitle)
+                })
                 // only show index page if it has show-tabs
                 .filter(child => (child as MdxFile).name !== 'index' || hasShowTabs(child as ExtendedPageItem))
                 .map(child => {

--- a/packages/theme/types.ts
+++ b/packages/theme/types.ts
@@ -31,7 +31,7 @@ export type FrontMatter = {
   description?: string
   filePath?: string
   keywords?: string[]
-  order?: number
+  menu_position?: number
   related?: {
     title: string
     href: string

--- a/packages/theme/types.ts
+++ b/packages/theme/types.ts
@@ -31,6 +31,7 @@ export type FrontMatter = {
   description?: string
   filePath?: string
   keywords?: string[]
+  order?: number
   related?: {
     title: string
     href: string


### PR DESCRIPTION

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="255" alt="Screenshot 2025-06-24 at 19 26 08" src="https://github.com/user-attachments/assets/79181ba2-a708-4312-be80-e0574b64e83c" />

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->
<img width="257" alt="Screenshot 2025-06-24 at 19 26 14" src="https://github.com/user-attachments/assets/ab224de9-55aa-4831-a1fe-7bf6686a6d16" />

</td>
</tr>
</table>
