### PR TITLE
Add auto-collapsed React code blocks for large code snippets.

### DIFF
--- a/.changeset/bright-parrots-smash.md
+++ b/.changeset/bright-parrots-smash.md
@@ -1,0 +1,11 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Add auto-collapsed React code blocks for large code snippets. This feature only applies to code fences with the `jsx live` language identifiers.
+
+E.g.
+
+```jsx live
+<>Your code</>
+```

--- a/packages/site/content/content-example/tabbed-component/react.mdx
+++ b/packages/site/content/content-example/tabbed-component/react.mdx
@@ -82,7 +82,7 @@ You can place an icon inside the Button in either the leading or the trailing po
 </Stack>
 ```
 
-### Animation
+### Collapsed long code blocks
 
 You can place an icon inside the Button in either the leading or the trailing position to enhance the visual context. It is recommended to use an [Octicon](https://primer.style/octicons) here.
 
@@ -95,12 +95,40 @@ You can place an icon inside the Button in either the leading or the trailing po
       Filter
     </Button>
   </Animate>
+  <Animate animate="fade-in">
+    <Button leadingVisual={<SearchIcon />}>Search</Button>
+    <Button trailingVisual={<ChevronDownIcon />}>Select</Button>
+    <Button leadingVisual={<FilterIcon />} trailingVisual={<ChevronDownIcon />}>
+      Filter
+    </Button>
+  </Animate>
+  <Animate animate="fade-in">
+    <Button leadingVisual={<SearchIcon />}>Search</Button>
+    <Button trailingVisual={<ChevronDownIcon />}>Select</Button>
+    <Button leadingVisual={<FilterIcon />} trailingVisual={<ChevronDownIcon />}>
+      Filter
+    </Button>
+  </Animate>
+  <Animate animate="fade-in">
+    <Button leadingVisual={<SearchIcon />}>Search</Button>
+    <Button trailingVisual={<ChevronDownIcon />}>Select</Button>
+    <Button leadingVisual={<FilterIcon />} trailingVisual={<ChevronDownIcon />}>
+      Filter
+    </Button>
+  </Animate>
+  <Animate animate="fade-in">
+    <Button leadingVisual={<SearchIcon />}>Search</Button>
+    <Button trailingVisual={<ChevronDownIcon />}>Select</Button>
+    <Button leadingVisual={<FilterIcon />} trailingVisual={<ChevronDownIcon />}>
+      Filter
+    </Button>
+  </Animate>
 </AnimationProvider>
 ```
 
 ### Images
 
-```
+```jsx live
 <>
   <img src="/images/avatar-mona.png" />
   <Avatar src="/images/avatar-mona.png" />

--- a/packages/theme/components/layout/code-block/ReactCodeBlock.module.css
+++ b/packages/theme/components/layout/code-block/ReactCodeBlock.module.css
@@ -28,6 +28,11 @@
   font-family: var(--brand-fontStack-monospace);
   background-color: var(--brand-color-canvas-subtle);
   overflow: auto;
+  position: relative;
+}
+
+.EditorWrapper {
+  position: relative;
 }
 
 .Editor pre {
@@ -35,6 +40,11 @@
   border-radius: 0;
   padding: var(--base-size-16) !important;
   background-color: var(--brand-color-canvas-subtle) !important;
+}
+
+.Editor--is-collapsed {
+  max-height: 400px;
+  overflow: hidden;
 }
 
 .Toolbar {
@@ -66,4 +76,45 @@
 
 .colorModeButtonActive {
   background-color: var(--brand-color-canvas-subtle);
+}
+
+.collapseButton {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  background-color: var(--brand-color-canvas-subtle);
+  border: none;
+  border-top: var(--brand-borderWidth-thin) solid var(--brand-color-border-default);
+  border-bottom-left-radius: var(--brand-borderRadius-medium);
+  border-bottom-right-radius: var(--brand-borderRadius-medium);
+  padding: var(--base-size-8) var(--base-size-12);
+  font-size: var(--brand-text-size-100);
+  font-family: var(--brand-fontStack-system);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--base-size-4);
+  z-index: 10;
+  transition: background-color var(--brand-animation-duration-default) var(--brand-animation-easing-glide);
+}
+
+.collapseButton--collapsed::before {
+  content: '';
+  position: absolute;
+  top: -41px;
+  left: 0;
+  width: 100%;
+  height: 40px;
+  background: linear-gradient(to bottom, transparent, var(--brand-color-canvas-subtle));
+  z-index: -1;
+}
+
+.collapseButton:hover,
+.collapseButton:focus {
+  background-color: var(--brand-color-canvas-default);
+}
+
+.collapseLabel {
+  font-size: var(--brand-text-size-100) !important;
 }


### PR DESCRIPTION
Adds auto collapsed React code block pane similar to primer.style/product (with some minor differences).

- Only enabled on `jsx live` code fences
- Auto-collapses code blocks that exceed a certain height
- Visual parity with product counterpart
- Simpler implementation, which doesn't require a separate `previewCode` and `fullCode` to determine what shows in collapsed and original states respectively.

 

https://github.com/user-attachments/assets/afbc9866-cf5e-4ec0-b74b-5f0e5a5ef745



<img width="990" alt="Screenshot 2025-06-25 at 11 37 23" src="https://github.com/user-attachments/assets/0895b0d1-39ac-4279-8211-47f1b74e11a7" />
<img width="995" alt="Screenshot 2025-06-25 at 11 37 16" src="https://github.com/user-attachments/assets/42d01f2d-7422-43e4-9d02-6bcbcf3250a8" />

