### PR TITLE
Fix breadcrumbs

### DIFF
--- a/.changeset/cool-cows-shake.md
+++ b/.changeset/cool-cows-shake.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Fixes breadcrumbs with duplicate and missing items

--- a/packages/site/content/components/primer/index.mdx
+++ b/packages/site/content/components/primer/index.mdx
@@ -2,6 +2,7 @@
 title: Primer
 description: Using custom Primer components in your pages
 show-tabs: true
+tab-label: Overview
 thumbnail: /images/placeholder-1200x630.png
 thumbnail_darkMode: /images/placeholder-1200x630-dark.png
 ---

--- a/packages/site/content/components/primer/index.mdx
+++ b/packages/site/content/components/primer/index.mdx
@@ -2,7 +2,6 @@
 title: Primer
 description: Using custom Primer components in your pages
 show-tabs: true
-tab-label: Overview
 thumbnail: /images/placeholder-1200x630.png
 thumbnail_darkMode: /images/placeholder-1200x630-dark.png
 ---

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -150,12 +150,17 @@ export function Theme({pageMap, children}: ThemeProps) {
                                   </Breadcrumbs.Item>
                                 )}
                                 {activePath.reduce((acc, item, index, items) => {
-                                  // Skip duplicate item for index pages without tab-label
+                                  // Skip folder items when followed by index pages with the same route
+                                  // BUT ONLY if the index page doesn't have a custom tab-label
+                                  // AND the index page's title doesn't match the folder's title
                                   if (
-                                    index > 0 &&
-                                    item.route === items[index - 1].route &&
+                                    index < items.length - 1 &&
+                                    items[index + 1].name === 'index' &&
+                                    item.route === items[index + 1].route &&
                                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                    !item.frontMatter?.['tab-label']
+                                    !items[index + 1].frontMatter?.['tab-label'] &&
+                                    // Keep both when the titles match (don't skip the folder)
+                                    items[index + 1].title !== item.title
                                   ) {
                                     return acc
                                   }
@@ -173,8 +178,6 @@ export function Theme({pageMap, children}: ThemeProps) {
                                       sx={{
                                         textTransform: 'capitalize',
                                         color: 'var(--brand-InlineLink-color-rest)',
-                                        pointerEvents: isLastItem ? 'none' : undefined,
-                                        cursor: isLastItem ? 'default' : undefined,
                                       }}
                                     >
                                       {itemTitle.replace(/-/g, ' ')}

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -149,40 +149,40 @@ export function Theme({pageMap, children}: ThemeProps) {
                                     {activeHeaderLink ? activeHeaderLink.title : siteTitle}
                                   </Breadcrumbs.Item>
                                 )}
-                                {(() => {
-                                  const items = [...activePath]
-
+                                {activePath.reduce((acc, item, index, items) => {
                                   // Skip duplicate item for index pages without tab-label
                                   if (
-                                    items.length > 1 &&
-                                    items[items.length - 1].route === items[items.length - 2].route &&
+                                    index > 0 &&
+                                    item.route === items[index - 1].route &&
                                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                    !items[items.length - 1].frontMatter?.['tab-label']
+                                    !item.frontMatter?.['tab-label']
                                   ) {
-                                    items.splice(items.length - 2, 1)
+                                    return acc
                                   }
 
-                                  return items.map((item, index) => {
-                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                    const itemTitle = item.frontMatter?.['tab-label'] || item.title
-                                    const isLastItem = index === items.length - 1
+                                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                  const itemTitle = item.frontMatter?.['tab-label'] || item.title
+                                  const isLastItem = index === items.length - 1
 
-                                    return (
-                                      <Breadcrumbs.Item
-                                        as={NextLink}
-                                        key={item.name}
-                                        href={item.route}
-                                        selected={isLastItem}
-                                        sx={{
-                                          textTransform: 'capitalize',
-                                          color: 'var(--brand-InlineLink-color-rest)',
-                                        }}
-                                      >
-                                        {itemTitle.replace(/-/g, ' ')}
-                                      </Breadcrumbs.Item>
-                                    )
-                                  })
-                                })()}
+                                  acc.push(
+                                    <Breadcrumbs.Item
+                                      as={NextLink}
+                                      key={`${item.name}-${index}`}
+                                      href={item.route}
+                                      selected={isLastItem}
+                                      sx={{
+                                        textTransform: 'capitalize',
+                                        color: 'var(--brand-InlineLink-color-rest)',
+                                        pointerEvents: isLastItem ? 'none' : undefined,
+                                        cursor: isLastItem ? 'default' : undefined,
+                                      }}
+                                    >
+                                      {itemTitle.replace(/-/g, ' ')}
+                                    </Breadcrumbs.Item>,
+                                  )
+
+                                  return acc
+                                }, [] as React.ReactNode[])}
                               </Breadcrumbs>
                             )}
 

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -152,13 +152,18 @@ export function Theme({pageMap, children}: ThemeProps) {
                                 {activePath.reduce((acc, item, index, items) => {
                                   const nextItem = items[index + 1]
 
-                                  // Skip duplicate item for index pages without tab-label
+                                  // Skip items in these cases:
+                                  // 1. When current item is a folder followed by its index page
+                                  // 2. When current item is an index page with a tab-label
                                   if (
-                                    index < items.length - 1 &&
-                                    nextItem.name === 'index' &&
-                                    item.route === nextItem.route &&
-                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                    !nextItem.frontMatter?.['tab-label']
+                                    (index < items.length - 1 &&
+                                      nextItem.name === 'index' &&
+                                      item.route === nextItem.route &&
+                                      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                      !nextItem.frontMatter?.['tab-label']) ||
+                                    (item.name === 'index' &&
+                                      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                      item.frontMatter?.['tab-label'])
                                   ) {
                                     return acc
                                   }

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -150,13 +150,15 @@ export function Theme({pageMap, children}: ThemeProps) {
                                   </Breadcrumbs.Item>
                                 )}
                                 {activePath.reduce((acc, item, index, items) => {
+                                  const nextItem = items[index + 1]
+
                                   // Skip duplicate item for index pages without tab-label
                                   if (
                                     index < items.length - 1 &&
-                                    items[index + 1].name === 'index' &&
-                                    item.route === items[index + 1].route &&
+                                    nextItem.name === 'index' &&
+                                    item.route === nextItem.route &&
                                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                    !items[index + 1].frontMatter?.['tab-label']
+                                    !nextItem.frontMatter?.['tab-label']
                                   ) {
                                     return acc
                                   }

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -149,46 +149,43 @@ export function Theme({pageMap, children}: ThemeProps) {
                                     {activeHeaderLink ? activeHeaderLink.title : siteTitle}
                                   </Breadcrumbs.Item>
                                 )}
-                                {activePath.reduce((acc, item, index, items) => {
-                                  const nextItem = items[index + 1]
+                                {activePath
+                                  .filter((item, index, array) => {
+                                    const nextItem = array[index + 1]
 
-                                  // Skip items in these cases:
-                                  // 1. When current item is a folder followed by its index page
-                                  // 2. When current item is an index page with a tab-label
-                                  if (
-                                    (index < items.length - 1 &&
-                                      nextItem.name === 'index' &&
-                                      item.route === nextItem.route &&
-                                      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                      !nextItem.frontMatter?.['tab-label']) ||
-                                    (item.name === 'index' &&
-                                      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                      item.frontMatter?.['tab-label'])
-                                  ) {
-                                    return acc
-                                  }
+                                    // Skip when current item is a folder followed by its index page
+                                    // or when it is an index page with a tabbed navigation
+                                    return !(
+                                      (index < array.length - 1 &&
+                                        nextItem.name === 'index' &&
+                                        item.route === nextItem.route &&
+                                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                        !nextItem.frontMatter?.['tab-label']) ||
+                                      (item.name === 'index' &&
+                                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                        item.frontMatter?.['tab-label'])
+                                    )
+                                  })
+                                  .map((item, index, visibleItems) => {
+                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                    const itemTitle = item.frontMatter?.['tab-label'] || item.title
+                                    const isLastItem = index === visibleItems.length - 1
 
-                                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                  const itemTitle = item.frontMatter?.['tab-label'] || item.title
-                                  const isLastItem = index === items.length - 1
-
-                                  acc.push(
-                                    <Breadcrumbs.Item
-                                      as={NextLink}
-                                      key={item.name}
-                                      href={item.route}
-                                      selected={isLastItem}
-                                      sx={{
-                                        textTransform: 'capitalize',
-                                        color: 'var(--brand-InlineLink-color-rest)',
-                                      }}
-                                    >
-                                      {itemTitle.replace(/-/g, ' ')}
-                                    </Breadcrumbs.Item>,
-                                  )
-
-                                  return acc
-                                }, [] as React.ReactNode[])}
+                                    return (
+                                      <Breadcrumbs.Item
+                                        as={NextLink}
+                                        key={item.name}
+                                        href={item.route}
+                                        selected={isLastItem}
+                                        sx={{
+                                          textTransform: 'capitalize',
+                                          color: 'var(--brand-InlineLink-color-rest)',
+                                        }}
+                                      >
+                                        {itemTitle.replace(/-/g, ' ')}
+                                      </Breadcrumbs.Item>
+                                    )
+                                  })}
                               </Breadcrumbs>
                             )}
 

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -170,7 +170,7 @@ export function Theme({pageMap, children}: ThemeProps) {
                                   acc.push(
                                     <Breadcrumbs.Item
                                       as={NextLink}
-                                      key={`${item.name}-${index}`}
+                                      key={item.name}
                                       href={item.route}
                                       selected={isLastItem}
                                       sx={{

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -149,22 +149,40 @@ export function Theme({pageMap, children}: ThemeProps) {
                                     {activeHeaderLink ? activeHeaderLink.title : siteTitle}
                                   </Breadcrumbs.Item>
                                 )}
-                                {activePath.map((item, index) => {
-                                  return (
-                                    <Breadcrumbs.Item
-                                      as={NextLink}
-                                      key={item.name}
-                                      href={item.route}
-                                      selected={index === activePath.length - 1}
-                                      sx={{
-                                        textTransform: 'capitalize',
-                                        color: 'var(--brand-InlineLink-color-rest)',
-                                      }}
-                                    >
-                                      {item.title.replace(/-/g, ' ')}
-                                    </Breadcrumbs.Item>
-                                  )
-                                })}
+                                {(() => {
+                                  const items = [...activePath]
+
+                                  // Skip duplicate item for index pages without tab-label
+                                  if (
+                                    items.length > 1 &&
+                                    items[items.length - 1].route === items[items.length - 2].route &&
+                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                    !items[items.length - 1].frontMatter?.['tab-label']
+                                  ) {
+                                    items.splice(items.length - 2, 1)
+                                  }
+
+                                  return items.map((item, index) => {
+                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                    const itemTitle = item.frontMatter?.['tab-label'] || item.title
+                                    const isLastItem = index === items.length - 1
+
+                                    return (
+                                      <Breadcrumbs.Item
+                                        as={NextLink}
+                                        key={item.name}
+                                        href={item.route}
+                                        selected={isLastItem}
+                                        sx={{
+                                          textTransform: 'capitalize',
+                                          color: 'var(--brand-InlineLink-color-rest)',
+                                        }}
+                                      >
+                                        {itemTitle.replace(/-/g, ' ')}
+                                      </Breadcrumbs.Item>
+                                    )
+                                  })
+                                })()}
                               </Breadcrumbs>
                             )}
 

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -150,17 +150,13 @@ export function Theme({pageMap, children}: ThemeProps) {
                                   </Breadcrumbs.Item>
                                 )}
                                 {activePath.reduce((acc, item, index, items) => {
-                                  // Skip folder items when followed by index pages with the same route
-                                  // BUT ONLY if the index page doesn't have a custom tab-label
-                                  // AND the index page's title doesn't match the folder's title
+                                  // Skip duplicate item for index pages without tab-label
                                   if (
                                     index < items.length - 1 &&
                                     items[index + 1].name === 'index' &&
                                     item.route === items[index + 1].route &&
                                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                    !items[index + 1].frontMatter?.['tab-label'] &&
-                                    // Keep both when the titles match (don't skip the folder)
-                                    items[index + 1].title !== item.title
+                                    !items[index + 1].frontMatter?.['tab-label']
                                   ) {
                                     return acc
                                   }


### PR DESCRIPTION
Fixes the issue of duplicate items on index pages and adds tabbed navigation labels to breadcrumbs.

| Before | After |
|--------|--------|
| ![screenshot-BGO9rYtr-000281@2x](https://github.com/user-attachments/assets/75c88a34-b40a-49fb-9c15-9a1ccf666ef8)     |  ![screenshot-UDQE1cxh-000282@2x](https://github.com/user-attachments/assets/061c6ea6-f179-4b93-bcd9-4d9179609684)   |
| ![screenshot-ZNZdTP65-000288@2x](https://github.com/user-attachments/assets/7a11cbba-4354-4ccc-b610-97c8d4faa4df) | ![screenshot-c5frWW9g-000287@2x](https://github.com/user-attachments/assets/29dd8a51-aff6-44bd-b9bf-243bc00b3525) |
| ![screenshot-qRWEMmg7-000289@2x](https://github.com/user-attachments/assets/a7d9c279-527b-426b-94b6-0ed89cfba67a) | ![screenshot-lXyswR7p-000290@2x](https://github.com/user-attachments/assets/6b6b3ad4-a959-4c1b-bbe6-e8ed06d0b73f)|