### PR TITLE
Fix breadcrumbs tabs title

### DIFF
--- a/.changeset/wild-mangos-pull.md
+++ b/.changeset/wild-mangos-pull.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Fixed a bug that caused breadcrumbs to display an incorrect title for pages with tabs

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -159,16 +159,18 @@ export function Theme({pageMap, children}: ThemeProps) {
                                       (index < array.length - 1 &&
                                         nextItem.name === 'index' &&
                                         item.route === nextItem.route &&
-                                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                        !nextItem.frontMatter?.['tab-label']) ||
-                                      (item.name === 'index' &&
-                                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                        item.frontMatter?.['tab-label'])
+                                        !nextItem.frontMatter['tab-label']) ||
+                                      (item.name === 'index' && item.frontMatter['tab-label'])
                                     )
                                   })
                                   .map((item, index, visibleItems) => {
-                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                                    const itemTitle = item.frontMatter?.['tab-label'] || item.title
+                                    const itemTitle = Array.isArray(item.children)
+                                      ? item.children.find(child => child.name === 'index')?.frontMatter.title ||
+                                        item.frontMatter['tab-label'] ||
+                                        item.frontMatter.title ||
+                                        item.title
+                                      : item.frontMatter['tab-label'] || item.frontMatter.title || item.title
+
                                     const isLastItem = index === visibleItems.length - 1
 
                                     return (


### PR DESCRIPTION
Fixes a bug that caused breadcrumbs to display an incorrect title for the current page.

| Before | After |
|--------|--------|
| ![screenshot-bhvvKvrJ-000295@2x](https://github.com/user-attachments/assets/e9f3c179-cd4a-4efa-be7f-006cf5c4719c) | ![screenshot-mzLF2RiU-000296@2x](https://github.com/user-attachments/assets/b6959d06-2d48-4178-9461-8e7734748a1f) | 