### PR TITLE
Update theme switcher aria label

### DIFF
--- a/.changeset/famous-steaks-kneel.md
+++ b/.changeset/famous-steaks-kneel.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Updated theme switcher aria label

--- a/packages/theme/components/layout/header/Header.tsx
+++ b/packages/theme/components/layout/header/Header.tsx
@@ -120,7 +120,7 @@ export function Header({siteTitle, flatDocsDirectories, pageMap}: HeaderProps) {
             <IconButton
               icon={colorMode === 'light' ? SunIcon : MoonIcon}
               variant="invisible"
-              aria-label={`Change color mode. Active mode is ${colorMode}.`}
+              aria-label={`Switch to ${colorMode === 'light' ? 'dark' : 'light'} mode`}
               onClick={() => setColorMode(colorMode === 'light' ? 'dark' : 'light')}
             />
             <IconButton


### PR DESCRIPTION
Resolves https://github.com/github/primer/issues/5380

Updates the theme switcher aria label to be consistent with the rest of primer.style.