### PR TITLE
Fix header link redirects

### DIFF
--- a/packages/site/app/layout.tsx
+++ b/packages/site/app/layout.tsx
@@ -23,12 +23,9 @@ const headerLinks: ThemeProps['headerLinks'] = [
     isActive: true,
   },
   {
-    href: 'https://primer.style/product',
-    title: 'Product UI',
-  },
-  {
-    href: 'https://primer.style/brand',
-    title: 'Brand UI',
+    href: 'https://primer.style',
+    title: 'Primer',
+    isExternal: true,
   },
   {
     href: 'https://primer.style/octicons',

--- a/packages/site/app/layout.tsx
+++ b/packages/site/app/layout.tsx
@@ -23,8 +23,13 @@ const headerLinks: ThemeProps['headerLinks'] = [
     isActive: true,
   },
   {
-    href: 'https://primer.style',
-    title: 'Primer',
+    href: 'https://primer.style/product',
+    title: 'Product UI',
+    isExternal: true,
+  },
+  {
+    href: 'https://primer.style/brand',
+    title: 'Brand UI',
     isExternal: true,
   },
   {

--- a/packages/site/app/layout.tsx
+++ b/packages/site/app/layout.tsx
@@ -25,12 +25,10 @@ const headerLinks: ThemeProps['headerLinks'] = [
   {
     href: 'https://primer.style/product',
     title: 'Product UI',
-    isExternal: true,
   },
   {
     href: 'https://primer.style/brand',
     title: 'Brand UI',
-    isExternal: true,
   },
   {
     href: 'https://primer.style/octicons',

--- a/packages/theme/components/layout/header/Header.tsx
+++ b/packages/theme/components/layout/header/Header.tsx
@@ -58,12 +58,12 @@ export function Header({siteTitle, flatDocsDirectories, pageMap}: HeaderProps) {
       aria-label="Header Navigation"
     >
       <div className={styles.Header__start}>
-        <Link href="/" className={styles.Header__siteTitle}>
+        <a href="/" className={styles.Header__siteTitle}>
           <MarkGithubIcon size={24} />
           <Text className={styles.Header__siteTitleText} as="p" size="200" weight="semibold">
             {siteTitle}
           </Text>
-        </Link>
+        </a>
         <Text as="span" className={styles.Header__separator} weight="semibold" aria-hidden>
           &#47;
         </Text>

--- a/packages/theme/components/layout/header/Header.tsx
+++ b/packages/theme/components/layout/header/Header.tsx
@@ -13,7 +13,6 @@ import {Stack, Text} from '@primer/react-brand'
 import {clsx} from 'clsx'
 import type {PageMapItem} from 'nextra'
 
-import Link from 'next/link'
 import styles from './Header.module.css'
 import {NavDrawer} from '../nav-drawer/NavDrawer'
 import {useNavDrawerState} from '../nav-drawer/useNavDrawerState'

--- a/packages/theme/components/layout/header/Header.tsx
+++ b/packages/theme/components/layout/header/Header.tsx
@@ -73,7 +73,7 @@ export function Header({siteTitle, flatDocsDirectories, pageMap}: HeaderProps) {
         <ul className={styles.Header__links}>
           {headerLinks.map(link => (
             <li key={link.href}>
-              <Link
+              <a
                 className={styles.Header__link}
                 href={link.href}
                 aria-current={link.isActive ? 'page' : undefined}
@@ -93,7 +93,7 @@ export function Header({siteTitle, flatDocsDirectories, pageMap}: HeaderProps) {
                     />
                   )}
                 </Text>
-              </Link>
+              </a>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Towards https://github.com/github/primer/issues/5379

Errors on primer.style indicate that using the Next `Link` component is triggering a prefetch of the reverse-proxied urls, which are failing. 

![Screenshot 2025-06-27 at 14 37 14](https://github.com/user-attachments/assets/eaff6ce4-4b1a-421b-8236-a6ca0c37c3b8)


This PR switches from `Link` to `<a>` to prevent the prefetch, while making minimal user-facing changes. These links don't need prefetching.

To test this feature resolves the parent Issue, we'll need to ship to production on Primer Brand and verify.
