### PR TITLE
Sidebar a11y fixes

### DIFF
--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -130,6 +130,18 @@ export function Theme({pageMap, children}: ThemeProps) {
                 <Header flatDocsDirectories={flatDocsDirectories} siteTitle={siteTitle} pageMap={pageMap} />
               </PRCBox>
               <PageLayout rowGap="none" columnGap="none" padding="none" containerWidth="full">
+                <PageLayout.Pane
+                  aria-label="Side navigation"
+                  width="small"
+                  sticky
+                  offsetHeader={65}
+                  padding="none"
+                  position="start"
+                  hidden={{narrow: true}}
+                  divider="line"
+                >
+                  <Sidebar pageMap={pageMap} />
+                </PageLayout.Pane>
                 <PageLayout.Content padding="normal">
                   <div id="main">
                     <PRCBox sx={!isHomePage && {maxWidth: 1200, width: '100%', margin: '0 auto'}}>
@@ -247,18 +259,6 @@ export function Theme({pageMap, children}: ThemeProps) {
                     </PRCBox>
                   </div>
                 </PageLayout.Content>
-                <PageLayout.Pane
-                  aria-label="Side navigation"
-                  width="small"
-                  sticky
-                  offsetHeader={65}
-                  padding="none"
-                  position="start"
-                  hidden={{narrow: true}}
-                  divider="line"
-                >
-                  <Sidebar pageMap={pageMap} />
-                </PageLayout.Pane>
               </PageLayout>
             </ContentWrapper>
           </BaseStyles>

--- a/packages/theme/components/layout/root-layout/Theme.tsx
+++ b/packages/theme/components/layout/root-layout/Theme.tsx
@@ -131,7 +131,6 @@ export function Theme({pageMap, children}: ThemeProps) {
               </PRCBox>
               <PageLayout rowGap="none" columnGap="none" padding="none" containerWidth="full">
                 <PageLayout.Pane
-                  aria-label="Side navigation"
                   width="small"
                   sticky
                   offsetHeader={65}
@@ -140,7 +139,9 @@ export function Theme({pageMap, children}: ThemeProps) {
                   hidden={{narrow: true}}
                   divider="line"
                 >
-                  <Sidebar pageMap={pageMap} />
+                  <aside aria-label={`${activeHeaderLink ? activeHeaderLink.title : siteTitle} sidebar`}>
+                    <Sidebar pageMap={pageMap} />
+                  </aside>
                 </PageLayout.Pane>
                 <PageLayout.Content padding="normal">
                   <div id="main">


### PR DESCRIPTION
Resolves https://github.com/github/primer/issues/5381

This pull request moves the sidebar before the content in the DOM and introduces an `aside` region to enhance accessibility. The aria-label now dynamically displays the appropriate title based on the active header link or site title.