### PR TITLE
Make Primer Brand lib a peer dependency

### DIFF
--- a/.changeset/orange-rats-know.md
+++ b/.changeset/orange-rats-know.md
@@ -4,4 +4,4 @@
 
 Moves `@primer/react-brand` to a peer-dependency.
 
-This changes prevents a mismatch of versions between Doctocat and the project using it. Going forward, the latter will be preferred.
+This change prevents a mismatch of versions between Doctocat and the project using it. Going forward, the latter will be preferred.

--- a/.changeset/orange-rats-know.md
+++ b/.changeset/orange-rats-know.md
@@ -1,0 +1,7 @@
+---
+'@primer/doctocat-nextjs': minor
+---
+
+Moves `@primer/react-brand` to a peer-dependency.
+
+This changes prevents a mismatch of versions between Doctocat and the project using it. Going forward, the latter will be preferred.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18684,13 +18684,12 @@
     },
     "packages/theme": {
       "name": "@primer/doctocat-nextjs",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "MIT",
       "dependencies": {
         "@next/mdx": "15.3.5",
         "@primer/octicons-react": "19.15.1",
         "@primer/react": "^37.11.0",
-        "@primer/react-brand": "0.54.0",
         "@types/lodash.debounce": "^4.0.9",
         "framer-motion": "12.4.0",
         "lodash.debounce": "^4.0.8",
@@ -18719,6 +18718,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
+        "@primer/react-brand": ">=0.54.0",
         "next": "^15.0.0",
         "react": ">=18.0.0 <20.0.0",
         "react-dom": ">=18.0.0 <20.0.0"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,6 +15,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "peerDependencies": {
+    "@primer/react-brand": ">=0.54.0",
     "next": "^15.0.0",
     "react": ">=18.0.0 <20.0.0",
     "react-dom": ">=18.0.0 <20.0.0"
@@ -23,7 +24,6 @@
     "@next/mdx": "15.3.5",
     "@primer/octicons-react": "19.15.1",
     "@primer/react": "^37.11.0",
-    "@primer/react-brand": "0.54.0",
     "@types/lodash.debounce": "^4.0.9",
     "framer-motion": "12.4.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
Moves Primer Brand library to be a peer dependency. This means that the consumer of Doctocat will need to declare `@primer/react-brand` an explicit devDependency going forward. 

The reason for this change is that a version mismatch bug is occurring in primer/brand, whereby the local @primer/react-brand dependency is newer than the one used in Doctocat. This led to a major bug, where outdated styles aren't appearing in the UI. This fixes that by ensuring that there is only ever one version of Primer Brand in-use at any given time.

